### PR TITLE
[Feature] 프로필 사진 변경 및 저장

### DIFF
--- a/src/main/java/com/overcomingroom/ulpet/awsS3/AwsS3Service.java
+++ b/src/main/java/com/overcomingroom/ulpet/awsS3/AwsS3Service.java
@@ -1,0 +1,146 @@
+package com.overcomingroom.ulpet.awsS3;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AwsS3Service {
+
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    /**
+     * 경로를 지정하고, s3에 이미지를 업로드합니다.
+     * /장소명/uuidFileNAme
+     *
+     * @param multipartFile 이미지
+     * @param dirName       폴더명(장소명)
+     * @return imageURL
+     * @throws IOException
+     */
+    @Transactional
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+
+        String uniqueFileName = getUniqueFileName(multipartFile);
+
+        String fileName = dirName + "/" + uniqueFileName;
+        File uploadFile = convertMultipartFileToFile(multipartFile, uniqueFileName);
+
+        // 이미지 업로드
+        String uploadImageUrl = putS3(uploadFile, fileName);
+
+        removeNewFile(uploadFile);
+        return uploadImageUrl;
+    }
+
+
+    /**
+     * uuid 를 이용해 unique한 fileName을 생성
+     *
+     * @param multipartFile
+     * @return fileName
+     */
+    private static String getUniqueFileName(MultipartFile multipartFile) {
+        // 파일 이름에서 공백을 제거한 새로운 파일 이름 생성
+        String originalFileName = multipartFile.getOriginalFilename();
+
+        // UUID를 파일명에 추가
+        String uuid = UUID.randomUUID().toString();
+        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
+        return uniqueFileName;
+    }
+
+    /**
+     * 로컬에 임시 저장된 업로드 파일을 삭제
+     *
+     * @param targetFile 삭제할 파일
+     */
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            log.info("파일이 삭제되었습니다.");
+        } else {
+            log.info("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    /**
+     * MultipartFile에서 File 로 변경합니다.
+     *
+     * @param file
+     * @param uniqueFileName
+     * @return
+     * @throws IOException
+     */
+    private File convertMultipartFileToFile(MultipartFile file, String uniqueFileName) throws IOException {
+
+        File convertFile = new File(uniqueFileName);
+        if (convertFile.createNewFile()) {
+            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
+                fos.write(file.getBytes());
+            } catch (IOException e) {
+                log.error("파일 변환 중 오류 발생: {}", e.getMessage());
+                throw e;
+            }
+            return convertFile;
+        }
+        throw new IllegalArgumentException(String.format("파일 변환에 실패했습니다. %s", file.getOriginalFilename()));
+    }
+
+    /**
+     * Uploads Amazon S3 bucket
+     *
+     * @param uploadFile
+     * @param fileName
+     * @return url
+     */
+    private String putS3(File uploadFile, String fileName) {
+        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    /**
+     * S3에서 image file 삭제
+     *
+     * @param fileName
+     */
+    public void deleteFile(String fileName) throws AmazonServiceException, UnsupportedEncodingException {
+
+        // URL 디코딩을 통해 원래의 파일 이름을 가져옴
+        String decodedFileName = URLDecoder.decode(fileName, "UTF-8");
+
+        String[] splitUrl = decodedFileName.split("/");
+        String imageFilename = splitUrl[splitUrl.length - 1];
+        String dirName = splitUrl[splitUrl.length - 2];
+        String setKey = dirName + "/" + imageFilename;
+
+        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, setKey);
+        try {
+            // 버킷에서 이미지 삭제
+            amazonS3.deleteObject(deleteObjectRequest);
+        } catch (AmazonServiceException e) {
+            log.error("Error while decoding the file name: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/overcomingroom/ulpet/awsS3/AwsS3Service.java
+++ b/src/main/java/com/overcomingroom/ulpet/awsS3/AwsS3Service.java
@@ -133,7 +133,8 @@ public class AwsS3Service {
         String[] splitUrl = decodedFileName.split("/");
         String imageFilename = splitUrl[splitUrl.length - 1];
         String dirName = splitUrl[splitUrl.length - 2];
-        String setKey = dirName + "/" + imageFilename;
+        String rootDirNAme = splitUrl[splitUrl.length - 3];
+        String setKey = rootDirNAme + "/" + dirName + "/" + imageFilename;
 
         DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, setKey);
         try {

--- a/src/main/java/com/overcomingroom/ulpet/certification/service/CertificationService.java
+++ b/src/main/java/com/overcomingroom/ulpet/certification/service/CertificationService.java
@@ -1,10 +1,6 @@
 package com.overcomingroom.ulpet.certification.service;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.DeleteObjectRequest;
-import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.overcomingroom.ulpet.awsS3.AwsS3Service;
 import com.overcomingroom.ulpet.certification.domain.dto.CertificationRequestDto;
 import com.overcomingroom.ulpet.certification.domain.dto.CertificationResponseDto;
 import com.overcomingroom.ulpet.certification.domain.entity.Certification;
@@ -23,21 +19,16 @@ import com.overcomingroom.ulpet.place.repository.PlaceRepository;
 import com.overcomingroom.ulpet.place.service.PlaceService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -51,11 +42,7 @@ public class CertificationService {
     private final MemberRepository memberRepository;
     private final PlaceImageRepository placeImageRepository;
     private final PlaceService placeService;
-
-    private final AmazonS3 amazonS3;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    private final AwsS3Service awsS3Service;
 
 
     /**
@@ -127,7 +114,7 @@ public class CertificationService {
         List<Feature> featureList = certificationRequestDto.getFeatureList();
 
         // 인증 이미지 S3에 업로드 ( 장소명 / 인증 사진명 )
-        String uploadImageUrl = upload(multipartFile, place.getPlaceName());
+        String uploadImageUrl = awsS3Service.upload(multipartFile, place.getPlaceName());
 
         place.getFeatures().addAll(featureRepository.saveAll(featureList));
 
@@ -158,119 +145,6 @@ public class CertificationService {
         return CertificationResponseDto.of(certification);
     }
 
-    /**
-     * 경로를 지정하고, s3에 이미지를 업로드합니다.
-     * /장소명/uuidFileNAme
-     *
-     * @param multipartFile 이미지
-     * @param dirName       폴더명(장소명)
-     * @return imageURL
-     * @throws IOException
-     */
-    @Transactional
-    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
-
-        String uniqueFileName = getUniqueFileName(multipartFile);
-
-        String fileName = dirName + "/" + uniqueFileName;
-        File uploadFile = convertMultipartFileToFile(multipartFile, uniqueFileName);
-
-        // 이미지 업로드
-        String uploadImageUrl = putS3(uploadFile, fileName);
-
-        removeNewFile(uploadFile);
-        return uploadImageUrl;
-    }
-
-
-    /**
-     * uuid 를 이용해 unique한 fileName을 생성
-     *
-     * @param multipartFile
-     * @return fileName
-     */
-    private static String getUniqueFileName(MultipartFile multipartFile) {
-        // 파일 이름에서 공백을 제거한 새로운 파일 이름 생성
-        String originalFileName = multipartFile.getOriginalFilename();
-
-        // UUID를 파일명에 추가
-        String uuid = UUID.randomUUID().toString();
-        String uniqueFileName = uuid + "_" + originalFileName.replaceAll("\\s", "_");
-        return uniqueFileName;
-    }
-
-    /**
-     * 로컬에 임시 저장된 업로드 파일을 삭제
-     *
-     * @param targetFile 삭제할 파일
-     */
-    private void removeNewFile(File targetFile) {
-        if (targetFile.delete()) {
-            log.info("파일이 삭제되었습니다.");
-        } else {
-            log.info("파일이 삭제되지 못했습니다.");
-        }
-    }
-
-    /**
-     * MultipartFile에서 File 로 변경합니다.
-     *
-     * @param file
-     * @param uniqueFileName
-     * @return
-     * @throws IOException
-     */
-    private File convertMultipartFileToFile(MultipartFile file, String uniqueFileName) throws IOException {
-
-        File convertFile = new File(uniqueFileName);
-        if (convertFile.createNewFile()) {
-            try (FileOutputStream fos = new FileOutputStream(convertFile)) {
-                fos.write(file.getBytes());
-            } catch (IOException e) {
-                log.error("파일 변환 중 오류 발생: {}", e.getMessage());
-                throw e;
-            }
-            return convertFile;
-        }
-        throw new IllegalArgumentException(String.format("파일 변환에 실패했습니다. %s", file.getOriginalFilename()));
-    }
-
-    /**
-     * Uploads Amazon S3 bucket
-     *
-     * @param uploadFile
-     * @param fileName
-     * @return url
-     */
-    private String putS3(File uploadFile, String fileName) {
-        amazonS3.putObject(new PutObjectRequest(bucket, fileName, uploadFile)
-                .withCannedAcl(CannedAccessControlList.PublicRead));
-        return amazonS3.getUrl(bucket, fileName).toString();
-    }
-
-    /**
-     * S3에서 image file 삭제
-     *
-     * @param fileName
-     */
-    public void deleteFile(String fileName) throws AmazonServiceException, UnsupportedEncodingException {
-
-        // URL 디코딩을 통해 원래의 파일 이름을 가져옴
-        String decodedFileName = URLDecoder.decode(fileName, "UTF-8");
-
-        String[] splitUrl = decodedFileName.split("/");
-        String imageFilename = splitUrl[splitUrl.length - 1];
-        String dirName = splitUrl[splitUrl.length - 2];
-        String setKey = dirName + "/" + imageFilename;
-
-        DeleteObjectRequest deleteObjectRequest = new DeleteObjectRequest(bucket, setKey);
-        try {
-            // 버킷에서 이미지 삭제
-            amazonS3.deleteObject(deleteObjectRequest);
-        } catch (AmazonServiceException e) {
-            log.error("Error while decoding the file name: {}", e.getMessage());
-        }
-    }
 
     /**
      * 인증 상세 정보를 반환 합니다.
@@ -366,7 +240,7 @@ public class CertificationService {
             }
             placeRepository.save(place);
             // S3 이미지 삭제
-            deleteFile(certificationImageUrl);
+            awsS3Service.deleteFile(certificationImageUrl);
             // 인증 삭제
             certificationRepository.delete(certification);
         }

--- a/src/main/java/com/overcomingroom/ulpet/certification/service/CertificationService.java
+++ b/src/main/java/com/overcomingroom/ulpet/certification/service/CertificationService.java
@@ -43,7 +43,7 @@ public class CertificationService {
     private final PlaceImageRepository placeImageRepository;
     private final PlaceService placeService;
     private final AwsS3Service awsS3Service;
-
+    private final String CERTIFICATION_PATH = "certification/";
 
     /**
      * 장소에 대한 인증 하기
@@ -59,7 +59,7 @@ public class CertificationService {
 
         // 이미지 파일이 없을 때
         if (multipartFile.isEmpty()) {
-            throw new IllegalArgumentException("이미지 파일을 첨부해주세요");
+            throw new CustomException(ErrorCode.NO_IMAGE);
         }
 
         // member 정보
@@ -113,8 +113,9 @@ public class CertificationService {
         // 특징 추가 목줄, 입마개등등 list 로 들어옴.
         List<Feature> featureList = certificationRequestDto.getFeatureList();
 
-        // 인증 이미지 S3에 업로드 ( 장소명 / 인증 사진명 )
-        String uploadImageUrl = awsS3Service.upload(multipartFile, place.getPlaceName());
+        // 인증 이미지 S3에 업로드 ( certification / 장소명 / 인증 사진명 )
+
+        String uploadImageUrl = awsS3Service.upload(multipartFile, CERTIFICATION_PATH + place.getPlaceName());
 
         place.getFeatures().addAll(featureRepository.saveAll(featureList));
 

--- a/src/main/java/com/overcomingroom/ulpet/exception/ErrorCode.java
+++ b/src/main/java/com/overcomingroom/ulpet/exception/ErrorCode.java
@@ -36,7 +36,10 @@ public enum ErrorCode {
     CERTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "인증 정보를 찾을 수 없습니다."),
     MEMBER_CERTIFICATION_LIST_IS_EMPTY(HttpStatus.NOT_FOUND, "멤버의 인증 정보가 비어있습니다."),
     CERTIFICATION_BEFORE_MIDNIGHT(HttpStatus.CONFLICT, "장소에 대한 하루 인증 횟수를 초과하였습니다. 해당 장소는 자정 이후에 인증이 가능합니다."),
-    NOT_AN_ALLOWED_AREA(HttpStatus.CONFLICT, "허용된 지역이 아닙니다.");
+    NOT_AN_ALLOWED_AREA(HttpStatus.CONFLICT, "허용된 지역이 아닙니다."),
+
+    // 이미지
+    NO_IMAGE(HttpStatus.BAD_REQUEST, "이미지를 첨부해 주세요");
 
     private final HttpStatus status;
     private final String msg;

--- a/src/main/java/com/overcomingroom/ulpet/member/controller/MemberController.java
+++ b/src/main/java/com/overcomingroom/ulpet/member/controller/MemberController.java
@@ -10,8 +10,13 @@ import com.overcomingroom.ulpet.response.ResponseCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 
 @RestController
 @RequestMapping("/v1/users")
@@ -39,12 +44,12 @@ public class MemberController {
         var isEmailExist = memberService.isEmailExist(email);
         ResponseCode responseCode = ResponseCode.MEMBER_EMAIL_CHECK_SUCCESS;
         return ResponseEntity.ok(
-            ResResult.builder()
-                .responseCode(responseCode)
-                .code(responseCode.getCode())
-                .message(responseCode.getMessage())
-                .data(isEmailExist)
-                .build()
+                ResResult.builder()
+                        .responseCode(responseCode)
+                        .code(responseCode.getCode())
+                        .message(responseCode.getMessage())
+                        .data(isEmailExist)
+                        .build()
         );
     }
 
@@ -66,12 +71,12 @@ public class MemberController {
     public ResponseEntity<ResResult> getUserId() {
         ResponseCode responseCode = ResponseCode.MEMBER_ID_GET_SUCCESS;
         return ResponseEntity.ok(
-            ResResult.builder()
-                .responseCode(responseCode)
-                .code(responseCode.getCode())
-                .message(responseCode.getMessage())
-                .data(memberService.getAuthenticatedUserId())
-                .build()
+                ResResult.builder()
+                        .responseCode(responseCode)
+                        .code(responseCode.getCode())
+                        .message(responseCode.getMessage())
+                        .data(memberService.getAuthenticatedUserId())
+                        .build()
         );
     }
 
@@ -104,7 +109,7 @@ public class MemberController {
     }
 
     @DeleteMapping("/{userId}/withdrawal")
-    public ResponseEntity<ResResult> withdrawalMember(@PathVariable("userId") Long userId) {
+    public ResponseEntity<ResResult> withdrawalMember(@PathVariable("userId") Long userId) throws UnsupportedEncodingException {
         ResponseCode responseCode = ResponseCode.MEMBER_WITHDRAWAL_SUCCESS;
         memberService.withdrawalMember(userId);
         return ResponseEntity.ok(
@@ -116,11 +121,14 @@ public class MemberController {
         );
     }
 
-    @PutMapping("/{userId}/profile")
-    public ResponseEntity<ResResult> updateMember(@PathVariable("userId") Long userId, @Valid @RequestBody
-    UpdateMemberRequestDto updateMemberRequestDto) {
+    @PutMapping(value = "/{userId}/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ResResult> updateMember(
+            @PathVariable("userId") Long userId,
+            @Valid @RequestPart(value = "updateMemberRequestDto") UpdateMemberRequestDto updateMemberRequestDto,
+            @RequestPart(value = "profileImage", required = false) MultipartFile multipartFile
+            ) throws IOException {
         ResponseCode responseCode = ResponseCode.MEMBER_UPDATE_SUCCESS;
-        Long memberId = memberService.updateMember(userId, updateMemberRequestDto);
+        Long memberId = memberService.updateMember(userId, updateMemberRequestDto, multipartFile);
         return ResponseEntity.ok(
                 ResResult.builder()
                         .responseCode(responseCode)

--- a/src/main/java/com/overcomingroom/ulpet/member/domain/dto/UpdateMemberRequestDto.java
+++ b/src/main/java/com/overcomingroom/ulpet/member/domain/dto/UpdateMemberRequestDto.java
@@ -11,10 +11,8 @@ public record UpdateMemberRequestDto(
 
     @NotBlank(message = "닉네임은 필수 입력 값입니다.")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
-    String nickname,
+    String nickname
 
-    @NotBlank(message = "프로필 이미지는 필수 입력 값입니다.")
-    String profileImage
 ) {
 
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #29 

## 📝 Description
S3에 사용자가 등록한 프로필 사진을 저장하고, 생성된 url을 DB에 저장합니다.

> ### 이미지 저장 과정
> 1. 사용자가 사진을 변경
> 2. S3에 변경된 사진 저장.
> 3. 사용자가 다시 한번 프로필 사진 변경
> 4. S3에 저장되어 있던 기존 사진 삭제 후 새로운 사진 저장

> ### 사용자 탈퇴
> 사용자가 탈퇴를 요청하면 S3에 프로필 사진 삭제